### PR TITLE
Handle `already subscribed` registration response

### DIFF
--- a/app/connectors/RegistrationConnector.scala
+++ b/app/connectors/RegistrationConnector.scala
@@ -18,13 +18,13 @@ package connectors
 
 import config.Service
 import models.registration.requests.RegistrationRequest
-import models.registration.responses.{NoMatchResponse, RegistrationResponse}
+import models.registration.responses.{AlreadySubscribedResponse, NoMatchResponse, RegistrationResponse}
 import play.api.Configuration
-import play.api.http.Status.{NOT_FOUND, OK}
+import play.api.http.Status.{CONFLICT, NOT_FOUND, OK}
 import play.api.libs.json.Json
 import play.api.libs.ws.writeableOf_JsValue
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, StringContextOps}
-import uk.gov.hmrc.http.HttpReads.Implicits._
+import uk.gov.hmrc.http.HttpReads.Implicits.*
 import uk.gov.hmrc.http.client.HttpClientV2
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -43,11 +43,9 @@ class RegistrationConnector @Inject()(
       .execute[HttpResponse]
       .map { response =>
         response.status match {
-          case OK =>
-            response.json.as[RegistrationResponse]
-
-          case NOT_FOUND =>
-            NoMatchResponse()
+          case OK => response.json.as[RegistrationResponse]
+          case NOT_FOUND => NoMatchResponse()
+          case CONFLICT => AlreadySubscribedResponse()
         }
       }
 }

--- a/app/models/registration/responses/AlreadySubscribedResponse.scala
+++ b/app/models/registration/responses/AlreadySubscribedResponse.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.registration.responses
+
+import play.api.libs.json.*
+
+final case class AlreadySubscribedResponse() extends RegistrationResponse
+
+object AlreadySubscribedResponse {
+
+  implicit lazy val writes: OWrites[AlreadySubscribedResponse] = new OWrites[AlreadySubscribedResponse] {
+
+    override def writes(o: AlreadySubscribedResponse): JsObject =
+      Json.obj("result" -> "alreadySubscribed")
+  }
+
+  implicit lazy val reads: Reads[AlreadySubscribedResponse] =
+    (__ \ "result")
+      .read[String]
+      .flatMap { t =>
+        if (t == "alreadySubscribed") {
+          Reads.pure(AlreadySubscribedResponse())
+        } else {
+          Reads.failed("could not read an already subscribed result")
+        }
+      }
+}

--- a/app/models/registration/responses/RegistrationResponse.scala
+++ b/app/models/registration/responses/RegistrationResponse.scala
@@ -24,7 +24,10 @@ trait RegistrationResponse
 object RegistrationResponse {
   
   implicit lazy val reads: Reads[RegistrationResponse] =
-    MatchResponseWithId.format.widen or MatchResponseWithoutId.format.widen or NoMatchResponse.reads.widen
+    MatchResponseWithId.format.widen or
+      MatchResponseWithoutId.format.widen or
+      NoMatchResponse.reads.widen or
+      AlreadySubscribedResponse.reads.widen
     
   implicit lazy val writes: OWrites[RegistrationResponse] = new OWrites[RegistrationResponse] {
     
@@ -33,6 +36,7 @@ object RegistrationResponse {
         case x: MatchResponseWithId => Json.toJsObject(x)(MatchResponseWithId.format)
         case x: MatchResponseWithoutId => Json.toJsObject(x)(MatchResponseWithoutId.format)
         case x: NoMatchResponse => Json.toJsObject(x)(NoMatchResponse.writes)
+        case x: AlreadySubscribedResponse => Json.toJsObject(x)(AlreadySubscribedResponse.writes)
       }
   }
 }

--- a/it/test/connectors/RegistrationConnectorSpec.scala
+++ b/it/test/connectors/RegistrationConnectorSpec.scala
@@ -70,14 +70,29 @@ class RegistrationConnectorSpec
 
       wireMockServer.stubFor(
         post(urlMatching("/digital-platform-reporting/register"))
-          .willReturn(ok(Json.toJson(response).toString))
+          .willReturn(notFound())
       )
 
       val result = connector.register(request).futureValue
 
       result mustEqual response
     }
-    
+
+    "must return an `already subscribed` response when the server returns CONFLICT" in {
+
+      val request = OrganisationWithUtr("utr", None)
+      val response = AlreadySubscribedResponse()
+
+      wireMockServer.stubFor(
+        post(urlMatching("/digital-platform-reporting/register"))
+          .willReturn(aResponse().withStatus(409))
+      )
+
+      val result = connector.register(request).futureValue
+
+      result mustEqual response
+    }
+
     "must return a failed future when the server returns an error" in {
 
 

--- a/test/models/registration/responses/RegistrationResponseSpec.scala
+++ b/test/models/registration/responses/RegistrationResponseSpec.scala
@@ -42,10 +42,18 @@ class RegistrationResponseSpec extends AnyFreeSpec with Matchers {
         val result = json.as[RegistrationResponse]
         result mustEqual response
       }
-      
+
       "a `no match`" in {
 
         val response = NoMatchResponse()
+        val json = Json.toJson(response)
+        val result = json.as[RegistrationResponse]
+        result mustEqual response
+      }
+
+      "an `already subscribed`" in {
+
+        val response = AlreadySubscribedResponse()
         val json = Json.toJson(response)
         val result = json.as[RegistrationResponse]
         result mustEqual response


### PR DESCRIPTION
### Description

Handles registration responses that indicate this entity is already subscribed

### Checklist PR Raiser

##### Before creating PR

- [ ] Have you run the tests?
- [ ] Have you run the journey tests? (where applicable)
- [ ] Have you addressed warnings where appropriate?
- [ ] Have you rebased against the current version of main?
- [ ] Have you checked code coverage isn’t lower than previously?
- [ ] Have you checked to ensure all dependencies are up-to-date?

##### After PRs been raised

- [ ] Have you checked the PR Builder passes?

### Checklist PR Reviewer

##### Before Reviewing

- [ ] Have you pulled the branch down?
- [ ] Have you assigned yourself to the PR?
- [ ] Have you moved the task to “in review” on JIRA?
- [ ] Have you checked to ensure all dependencies are up-to-date?
- [ ] Have you checked to ensure branch has been rebased against the current version of main?

##### Whilst Reviewing

- [ ] Have you run the tests?
- [ ] Have you run the journey tests?
- [ ] Have you looked at the JIRA story to make sure all Acceptance Criteria has been met?

##### After Reviewing

- [ ] Have you checked for merge conflicts or any changes in the current main that may affect the current pull request?
  i.e. does it need another rebase?
- [ ] Have you checked to make sure there are no builds in the pipeline before you merge?
- [ ] Have you moved the task to “in pipeline” on Jira?
