### PR TITLE
[ODPR-1424] - Bug fix. businessName on RegistrationConfirmation

### DIFF
--- a/app/models/SubscriptionDetails.scala
+++ b/app/models/SubscriptionDetails.scala
@@ -51,20 +51,22 @@ object SubscriptionDetails {
   }
 
   private def getBusinessName(userAnswers: UserAnswers): Option[String] =
-    userAnswers.get(BusinessTypePage).flatMap {
-      case Individual | SoleTrader => None
-      case _ => userAnswers.registrationResponse.flatMap {
-        case x: MatchResponseWithId => x.organisationName
-        case x: MatchResponseWithoutId => userAnswers.get(BusinessNameNoUtrPage)
-        case _ => None
+    if (userAnswers.get(BusinessTypePage).nonEmpty) {
+      userAnswers.get(BusinessTypePage).flatMap {
+        case Individual | SoleTrader => None
+        case _ => userAnswers.registrationResponse.flatMap {
+          case x: MatchResponseWithId => x.organisationName
+          case x: MatchResponseWithoutId => userAnswers.get(BusinessNameNoUtrPage)
+          case _ => None
+        }
       }
-    }.orElse {
+    }
+    else {
       userAnswers.registrationResponse.flatMap {
         case x: MatchResponseWithId => x.organisationName
         case _ => None
       }
     }
-
   def encryptedFormat(implicit crypto: Encrypter with Decrypter): OFormat[SubscriptionDetails] = {
 
     implicit val sensitiveFormat: Format[SensitiveString] =

--- a/test/models/SubscriptionDetailsSpec.scala
+++ b/test/models/SubscriptionDetailsSpec.scala
@@ -61,7 +61,7 @@ class SubscriptionDetailsSpec extends AnyFreeSpec with Matchers {
       json.as[SubscriptionDetails](SubscriptionDetails.encryptedFormat(implicitly)) mustEqual subscriptionDetails
     }
 
-    "must correctly create SubscriptionDetails when MatchResponseWithID" in {
+    "must correctly create SubscriptionDetails when Org, MatchResponseWithID" in {
       val registrationResponse = MatchResponseWithId("safeId", anAddress, Some("Testing 1 Ltd"))
       val response = SubscribedResponse("dprsId", Instant.parse("2024-03-17T09:30:47Z"))
       val request = aSubscriptionRequest
@@ -74,7 +74,7 @@ class SubscriptionDetailsSpec extends AnyFreeSpec with Matchers {
       SubscriptionDetails.apply(response, request, userAnswers) mustEqual subscriptionDetails
     }
 
-    "must correctly create SubscriptionDetails when MatchResponseWithoutID" in {
+    "must correctly create SubscriptionDetails when Org, MatchResponseWithoutID" in {
       val registrationResponse = MatchResponseWithoutId("safeId")
       val response = SubscribedResponse("dprsId", Instant.parse("2024-03-17T09:30:47Z"))
       val request = aSubscriptionRequest
@@ -88,7 +88,7 @@ class SubscriptionDetailsSpec extends AnyFreeSpec with Matchers {
       SubscriptionDetails.apply(response, request, userAnswers) mustEqual subscriptionDetails
     }
 
-    "must correctly create SubscriptionDetails when RegistrationType is ThirdParty Individual" in {
+    "must correctly create SubscriptionDetails ThirdParty Individual, MatchResponseWithoutId" in {
       val registrationResponse = MatchResponseWithoutId("safeId")
       val response = SubscribedResponse("dprsId", Instant.parse("2024-03-17T09:30:47Z"))
       val request = aSubscriptionRequest
@@ -101,7 +101,7 @@ class SubscriptionDetailsSpec extends AnyFreeSpec with Matchers {
       SubscriptionDetails.apply(response, request, userAnswers) mustEqual subscriptionDetails
     }
 
-    "must correctly create SubscriptionDetails when RegistrationType is ThirdParty Sole Trader" in {
+    "must correctly create SubscriptionDetails when ThirdParty Sole Trader, MatchResponseWithoutId" in {
       val registrationResponse = MatchResponseWithoutId("safeId")
       val response = SubscribedResponse("dprsId", Instant.parse("2024-03-17T09:30:47Z"))
       val request = aSubscriptionRequest
@@ -114,7 +114,33 @@ class SubscriptionDetailsSpec extends AnyFreeSpec with Matchers {
       SubscriptionDetails.apply(response, request, userAnswers) mustEqual subscriptionDetails
     }
 
-    "must correctly create SubscriptionDetails when RegistrationType is ThirdParty but not Individual MatchResponseWithoutId" in {
+    "must correctly create SubscriptionDetails when ThirdParty Sole Trader, MatchResponseWithId" in {
+      val registrationResponse = MatchResponseWithId("safeId", anAddress, Some("Testing 1 Ltd"))
+      val response = SubscribedResponse("dprsId", Instant.parse("2024-03-17T09:30:47Z"))
+      val request = aSubscriptionRequest
+      val userAnswers = aUserAnswers
+        .copy(registrationResponse = Some(registrationResponse))
+        .set(RegistrationTypePage, RegistrationType.ThirdParty).success.value
+        .set(BusinessTypePage, BusinessType.SoleTrader).success.value
+      val subscriptionDetails = SubscriptionDetails(response, request, ThirdParty, Some(BusinessType.SoleTrader), None)
+
+      SubscriptionDetails.apply(response, request, userAnswers) mustEqual subscriptionDetails
+    }
+
+    "must correctly create SubscriptionDetails when ThirdParty Individual, MatchResponseWithId" in {
+      val registrationResponse = MatchResponseWithId("safeId", anAddress, Some("Testing 1 Ltd"))
+      val response = SubscribedResponse("dprsId", Instant.parse("2024-03-17T09:30:47Z"))
+      val request = aSubscriptionRequest
+      val userAnswers = aUserAnswers
+        .copy(registrationResponse = Some(registrationResponse))
+        .set(RegistrationTypePage, RegistrationType.ThirdParty).success.value
+        .set(BusinessTypePage, BusinessType.Individual).success.value
+      val subscriptionDetails = SubscriptionDetails(response, request, ThirdParty, Some(BusinessType.Individual), None)
+
+      SubscriptionDetails.apply(response, request, userAnswers) mustEqual subscriptionDetails
+    }
+
+    "must correctly create SubscriptionDetails when ThirdParty Org, MatchResponseWithoutId" in {
       val registrationResponse = MatchResponseWithoutId("safeId")
       val response = SubscribedResponse("dprsId", Instant.parse("2024-03-17T09:30:47Z"))
       val request = aSubscriptionRequest
@@ -128,7 +154,7 @@ class SubscriptionDetailsSpec extends AnyFreeSpec with Matchers {
       SubscriptionDetails.apply(response, request, userAnswers) mustEqual subscriptionDetails
     }
 
-    "must correctly create SubscriptionDetails when RegistrationType is ThirdParty but not Individual MatchResponseWithId" in {
+    "must correctly create SubscriptionDetails when ThirdParty Individual MatchResponseWithId" in {
       val registrationResponse = MatchResponseWithId("safeId", anAddress, Some("Testing 4 Ltd"))
       val response = SubscribedResponse("dprsId", Instant.parse("2024-03-17T09:30:47Z"))
       val request = aSubscriptionRequest


### PR DESCRIPTION
### Description

- Bug: if soleTrader or Individual and they match with Id (UTR or NINO) then the RegistrationConfirmationPage shows '[BusinessName] has succesfully....' should be 'You have successfully....'
- Fix: Added if/else statement in the BusinessName method 

### Checklist PR Raiser

##### Before creating PR

- [x] Have you run the tests?
- [x] Have you run the journey tests? (where applicable)
- [ ] Have you addressed warnings where appropriate?
- [x] Have you rebased against the current version of main?
- [ ] Have you checked code coverage isn’t lower than previously?
- [x] Have you checked to ensure all dependencies are up-to-date?

##### After PRs been raised

- [ ] Have you checked the PR Builder passes?

### Checklist PR Reviewer

##### Before Reviewing

- [ ] Have you pulled the branch down?
- [ ] Have you assigned yourself to the PR?
- [ ] Have you moved the task to “in review” on JIRA?
- [ ] Have you checked to ensure all dependencies are up-to-date?
- [ ] Have you checked to ensure branch has been rebased against the current version of main?

##### Whilst Reviewing

- [ ] Have you run the tests?
- [ ] Have you run the journey tests?
- [ ] Have you looked at the JIRA story to make sure all Acceptance Criteria has been met?

##### After Reviewing

- [ ] Have you checked for merge conflicts or any changes in the current main that may affect the current pull request?
  i.e. does it need another rebase?
- [ ] Have you checked to make sure there are no builds in the pipeline before you merge?
- [ ] Have you moved the task to “in pipeline” on Jira?
